### PR TITLE
fix: correct wildcard usage in move route

### DIFF
--- a/src/routes/notes.ts
+++ b/src/routes/notes.ts
@@ -69,8 +69,8 @@ export default async function route(app: FastifyInstance) {
     });
 
 
-    app.post('/notes/*/move', async (req, reply) => {
-        const p = (req.params as any)['*'];
+    app.post('/notes/:path/move', async (req, reply) => {
+        const p = (req.params as any).path;
         const { newPath } = req.body as any;
         const from = vaultResolve(p);
         const to = vaultResolve(newPath);


### PR DESCRIPTION
## Summary
- use path param instead of unsupported wildcard in move route

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'chokidar')*

------
https://chatgpt.com/codex/tasks/task_e_68a48da86dac8332b3d5a8b214a9ad84