### PR TITLE
Document API routes and serve OpenAPI spec

### DIFF
--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -11,13 +11,60 @@ components:
     bearerAuth:
       type: http
       scheme: bearer
+  schemas:
+    NoteFrontmatter:
+      type: object
+      additionalProperties: true
+    TOCItem:
+      type: object
+      properties:
+        level:
+          type: integer
+        title:
+          type: string
+      required: [level, title]
+    NoteResponse:
+      type: object
+      properties:
+        path:
+          type: string
+        frontmatter:
+          $ref: '#/components/schemas/NoteFrontmatter'
+        content:
+          type: string
+        etag:
+          type: string
+        toc:
+          type: array
+          items:
+            $ref: '#/components/schemas/TOCItem'
+      required: [path, frontmatter, content, etag]
+    SearchResponse:
+      type: object
+      properties:
+        hits:
+          type: array
+          items:
+            type: object
+            properties:
+              path:
+                type: string
+              title:
+                type: string
+              snippet:
+                type: string
+              score:
+                type: number
+            required: [path, title, snippet]
+      required: [hits]
 paths:
   /health:
     get:
       operationId: health
       summary: Health check
+      security: []
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
@@ -26,32 +73,209 @@ paths:
                 properties:
                   ok:
                     type: boolean
-  /search:
-    get:
-      operationId: searchNotes
-      summary: Full-text search
-      parameters:
-        - in: query
-          name: q
-          required: true
-          schema:
-            type: string
-        - in: query
-          name: limit
-          schema:
-            type: integer
-            default: 10
-            minimum: 1
-            maximum: 50
+                required: [ok]
+  /notes:
+    post:
+      operationId: createNote
+      summary: Create note
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+                frontmatter:
+                  $ref: '#/components/schemas/NoteFrontmatter'
+                content:
+                  type: string
+              required: [path]
       responses:
-        "200":
-          description: Results
+        '201':
+          description: Created
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  hits:
-                    type: array
-        "201":
+                  ok:
+                    type: boolean
+                required: [ok]
+  /notes/{path}:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getNote
+      summary: Read note
+      parameters:
+        - name: section
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Note
+          headers:
+            ETag:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoteResponse'
+    patch:
+      operationId: updateNote
+      summary: Update note
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                frontmatter:
+                  $ref: '#/components/schemas/NoteFrontmatter'
+                content:
+                  type: string
+      responses:
+        '200':
+          description: Updated
+          headers:
+            ETag:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required: [ok]
+    delete:
+      operationId: deleteNote
+      summary: Delete note
+      parameters:
+        - name: If-Match
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required: [ok]
+  /notes/{path}/move:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      operationId: moveNote
+      summary: Move note
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                newPath:
+                  type: string
+              required: [newPath]
+      responses:
+        '200':
+          description: Moved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required: [ok]
+  /folders:
+    get:
+      operationId: listFolders
+      summary: List folder tree
+      responses:
+        '200':
+          description: Tree
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+    post:
+      operationId: createFolder
+      summary: Create folder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  type: string
+              required: [path]
+      responses:
+        '200':
           description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                required: [ok]
+  /search:
+    get:
+      operationId: searchNotes
+      summary: Full-text search
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 10
+      responses:
+        '200':
+          description: Results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchResponse'
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,9 @@
 import Fastify from 'fastify';
 import helmet from '@fastify/helmet';
 import rateLimit from '@fastify/rate-limit';
+import fs from 'node:fs';
+import { parse } from 'yaml';
 import { CONFIG } from './config.js';
-
 
 // Routes
 import health from './routes/health.js';
@@ -10,17 +11,23 @@ import notes from './routes/notes.js';
 import folders from './routes/folders.js';
 import search from './routes/search.js';
 
+const openapi = parse(
+    fs.readFileSync(new URL('../openapi/noteapi.yaml', import.meta.url), 'utf8')
+);
 
 const app = Fastify({ logger: true });
 await app.register(helmet);
 await app.register(rateLimit, { max: 300, timeWindow: '1 minute' });
 
+app.get('/openapi.json', async (_req, reply) => {
+    reply.header('Content-Type', 'application/json');
+    return openapi;
+});
 
 await app.register(health);
 await app.register(notes);
 await app.register(folders);
 await app.register(search);
-
 
 app.listen({ host: CONFIG.host, port: CONFIG.port })
     .then(() => {
@@ -30,3 +37,4 @@ app.listen({ host: CONFIG.host, port: CONFIG.port })
         app.log.error(err);
         process.exit(1);
     });
+


### PR DESCRIPTION
## Summary
- expand OpenAPI description to cover health, notes, folders, and search endpoints with schemas
- expose `/openapi.json` route that serves the parsed OpenAPI spec

## Testing
- `npm test`
- `curl -s http://127.0.0.1:3000/health`
- `curl -s http://127.0.0.1:3000/openapi.json | jq '.paths | keys'`

------
https://chatgpt.com/codex/tasks/task_e_68a4d3efb3a08332958f53472631e78c