### PR TITLE
Index vault on startup for search

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,28 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import matter from 'gray-matter';
-import { CONFIG } from '../config.js';
-import { index, toSearchDoc } from '../search/meili.js';
-import { isMarkdown } from '../utils/paths.js';
-
-async function walk(dir: string): Promise<string[]> {
-    const entries = await fs.readdir(dir, { withFileTypes: true });
-    const files: string[] = [];
-    for (const e of entries) {
-        if (e.name === '.stfolder') continue;
-        if (e.name.startsWith('.')) continue;
-        const abs = path.join(dir, e.name);
-        if (e.isDirectory()) {
-            files.push(...await walk(abs));
-        } else if (e.isFile()) {
-            if (!isMarkdown(abs)) continue;
-            if (e.name.includes('sync-conflict')) continue;
-            files.push(abs);
-        }
-    }
-    return files;
-}
+import { reindexAll } from '../search/indexer.js';
 
 export default async function route(app: FastifyInstance) {
     app.addHook('onRequest', async (req, reply) => {
@@ -34,17 +11,8 @@ export default async function route(app: FastifyInstance) {
     });
 
     app.post('/admin/reindex', async () => {
-        const absPaths = await walk(CONFIG.vaultRoot);
-        const docs = [];
-        for (const abs of absPaths) {
-            const rel = path.relative(CONFIG.vaultRoot, abs).split(path.sep).join('/');
-            const buf = await fs.readFile(abs, 'utf8');
-            const parsed = matter(buf);
-            const stat = await fs.stat(abs);
-            docs.push(toSearchDoc({ path: rel, frontmatter: parsed.data ?? {}, content: parsed.content, mtime: stat.mtimeMs }));
-        }
-        if (docs.length) await index.addDocuments(docs);
-        return { indexed: docs.length };
+        const indexed = await reindexAll();
+        return { indexed };
     });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import notes from './routes/notes.js';
 import folders from './routes/folders.js';
 import search from './routes/search.js';
 import admin from './routes/admin.js';
+import { reindexAll } from './search/indexer.js';
 
 const openapi = parse(
     fs.readFileSync(new URL('../openapi/noteapi.yaml', import.meta.url), 'utf8')
@@ -30,6 +31,13 @@ await app.register(notes);
 await app.register(folders);
 await app.register(search);
 await app.register(admin);
+
+try {
+    const count = await reindexAll();
+    app.log.info(`Indexed ${count} notes`);
+} catch (err) {
+    app.log.error({ err }, 'Failed to build search index');
+}
 
 app.listen({ host: CONFIG.host, port: CONFIG.port })
     .then(() => {


### PR DESCRIPTION
## Summary
- add helper to crawl vault and index notes in Meilisearch
- run reindexing at server start so search results appear
- simplify admin reindex route to use shared helper

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5840f2bc08332857c02d4d9da5614