### PR TITLE
chore: update Meilisearch to latest version

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -23,12 +23,12 @@ You are an assistant developer. Your job is to implement endpoints and utilities
 - Always normalize and validate paths (use `utils/paths.ts`).
 - Keep pure functions testable. No side effects in helpers.
 - Copy docker-compose.yml.example to docker-compose.yml while testing (do not commit)
-- Validate that interactions with meilisearch follows best practices, functions and parameters in line with versions 1.11.3 (to avoid deprecation / bad code issues) 
+- Validate that interactions with Meilisearch follow best practices and remain compatible with the current server version.
 
 ## Test instructions
 
-- Do not use docker for tests 
-- Use meilisearch version 1.11.3 if possible https://github.com/meilisearch/meilisearch/releases/tag/v1.11.3
+- Do not use docker for tests
+- Use the latest stable Meilisearch release (currently 1.18.0) if possible https://github.com/meilisearch/meilisearch/releases/tag/v1.18.0
 
 ## Tests
 - Do not use Docker for tests 

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   meili:
-    image: getmeili/meilisearch:v1.11
+    image: getmeili/meilisearch:v1.18
     environment:
       MEILI_ENV: production
       MEILI_MASTER_KEY: ${MEILI_MASTER_KEY}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "fastify": "^4.28.1",
         "gray-matter": "^4.0.3",
         "mdast-util-to-string": "^4.0.0",
-        "meilisearch": "^0.39.0",
+        "meilisearch": "^0.52.0",
         "remark-parse": "^11.0.0",
         "unified": "^11.0.5",
         "yaml": "^2.5.1"
@@ -674,15 +674,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1122,13 +1113,10 @@
       }
     },
     "node_modules/meilisearch": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.39.0.tgz",
-      "integrity": "sha512-nNf/HOqQ/wSxaSYKyIsE8thMPciLyIpEDIp0ZbJxkOZ/tETDNfaBNbY+Eq/wbTR9O769QSiQFf5OhssfGyOzbA==",
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.1.6"
-      }
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/meilisearch/-/meilisearch-0.52.0.tgz",
+      "integrity": "sha512-RqPsB4a78sXf/ATB7PIVvKCG7yf0y1M+uCj8Z9Wku44WmCy3iz0C1PHjVV5xphQolo09CdhdyFoRxHQSJkOdpg==",
+      "license": "MIT"
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -1578,26 +1566,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -1869,12 +1837,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/trough": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
@@ -1984,22 +1946,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@fastify/rate-limit": "^8.0.0",
     "gray-matter": "^4.0.3",
     "mdast-util-to-string": "^4.0.0",
-    "meilisearch": "^0.39.0",
+    "meilisearch": "^0.52.0",
     "remark-parse": "^11.0.0",
     "unified": "^11.0.5",
     "yaml": "^2.5.1"

--- a/src/search/meili.ts
+++ b/src/search/meili.ts
@@ -6,17 +6,19 @@ export const meili = new MeiliSearch({ host: CONFIG.meili.host, apiKey: CONFIG.m
 
 async function ensureIndex() {
     try {
-        await meili.createIndex(CONFIG.meili.index, { primaryKey: 'path' });
+        const task = await meili.createIndex(CONFIG.meili.index, { primaryKey: 'path' });
+        if ('taskUid' in task) await meili.tasks.waitForTask(task.taskUid);
     } catch (err: any) {
         // ignore if index already exists
     }
     const idx = meili.index(CONFIG.meili.index);
     try {
-        await idx.updateSettings({
+        const task = await idx.updateSettings({
             searchableAttributes: ['title', 'headings', 'content', 'path'],
             displayedAttributes: ['path', 'title', 'headings', 'frontmatter', 'content'],
             filterableAttributes: ['path']
         });
+        if ('taskUid' in task) await idx.tasks.waitForTask(task.taskUid);
     } catch {
         // ignore unsupported settings
     }


### PR DESCRIPTION
## Summary
- upgrade Meilisearch client to v0.52 and server image to v1.18
- ensure index creation/settings wait for tasks to complete
- document using the latest stable Meilisearch in AGENTS instructions

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5b78662f483329b8ab7a11d859ff6