### PR TITLE
refactor: centralize config access

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ export const CONFIG = {
   baseUrl: process.env.BASE_URL ?? 'http://127.0.0.1:3000',
   vaultRoot: process.env.VAULT_ROOT ?? '/vault',
   apiKey: process.env.NOTEAPI_KEY ?? '',
+  trashEnabled: process.env.TRASH_ENABLED === 'true',
   meili: {
     host: process.env.MEILI_HOST ?? 'http://127.0.0.1:7700',
     key: process.env.MEILI_MASTER_KEY ?? '',

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,11 +1,12 @@
 import { FastifyInstance } from 'fastify';
 import { reindexAll } from '../search/indexer.js';
+import { CONFIG } from '../config.js';
 
 export default async function route(app: FastifyInstance) {
     app.addHook('onRequest', async (req, reply) => {
         const auth = req.headers['authorization'];
         const key = (auth ?? '').toString().replace(/^Bearer\s+/i, '');
-        if (!key || key !== process.env.NOTEAPI_KEY) {
+        if (!key || key !== CONFIG.apiKey) {
             reply.code(401).send({ error: 'Unauthorized' });
         }
     });

--- a/src/routes/folders.ts
+++ b/src/routes/folders.ts
@@ -26,7 +26,7 @@ export default async function route(app: FastifyInstance) {
     app.addHook('onRequest', async (req, reply) => {
         const auth = req.headers['authorization'];
         const key = (auth ?? '').toString().replace(/^Bearer\s+/i, '');
-        if (!key || key !== process.env.NOTEAPI_KEY) {
+        if (!key || key !== CONFIG.apiKey) {
             reply.code(401).send({ error: 'Unauthorized' });
         }
     });

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,5 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { index, decodePath } from '../search/meili.js';
+import { CONFIG } from '../config.js';
 
 
 export default async function route(app: FastifyInstance) {
@@ -7,7 +8,7 @@ export default async function route(app: FastifyInstance) {
     app.addHook('onRequest', async (req, reply) => {
         const auth = req.headers['authorization'];
         const key = (auth ?? '').toString().replace(/^Bearer\s+/i, '');
-        if (!key || key !== process.env.NOTEAPI_KEY) {
+        if (!key || key !== CONFIG.apiKey) {
             reply.code(401).send({ error: 'Unauthorized' });
         }
     });

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,25 +1,7 @@
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
-
-
-export const CONFIG = {
-    host: process.env.HOST ?? '127.0.0.1',
-    port: Number(process.env.PORT ?? 3000),
-    baseUrl: process.env.BASE_URL ?? 'http://127.0.0.1:3000',
-    vaultRoot: process.env.VAULT_ROOT ?? '/vault',
-    apiKey: process.env.NOTEAPI_KEY ?? '',
-    meili: {
-        host: process.env.MEILI_HOST ?? 'http://127.0.0.1:7700',
-        key: process.env.MEILI_MASTER_KEY ?? '',
-        index: process.env.MEILI_INDEX ?? 'notes'
-    }
-};
-
-
-if (!fs.existsSync(CONFIG.vaultRoot)) {
-    console.warn(`[WARN] VAULT_ROOT does not exist: ${CONFIG.vaultRoot}`);
-}
+import { CONFIG } from '../config.js';
 
 const REAL_VAULT_ROOT = fs.existsSync(CONFIG.vaultRoot)
     ? fs.realpathSync(CONFIG.vaultRoot)


### PR DESCRIPTION
## Summary
- export CONFIG as single source of truth and include trashEnabled flag
- use shared CONFIG in utils and routes instead of re-reading env vars

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61397d7848332a97086529f21f171