### PR TITLE
Add comprehensive integration tests for API endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/server.ts",
     "build": "tsc -p .",
     "start": "node dist/server.js",
-    "test": "node --test"
+    "test": "node --test --test-concurrency=1"
   },
   "dependencies": {
     "fastify": "^4.28.1",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,196 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn, execSync } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import Fastify from 'fastify';
+
+async function ensureMeili() {
+    try {
+        await fs.access('./meilisearch');
+    } catch {
+        execSync('curl -fsSL https://install.meilisearch.com | sh');
+    }
+}
+
+const MEILI_URL = 'http://127.0.0.1:7702';
+
+async function waitForMeili() {
+    for (let i = 0; i < 50; i++) {
+        try {
+            const res = await fetch(MEILI_URL + '/health');
+            if (res.ok) return;
+        } catch {}
+        await delay(100);
+    }
+    throw new Error('Meilisearch failed to start');
+}
+
+async function waitFor(fn) {
+    for (let i = 0; i < 50; i++) {
+        if (await fn()) return;
+        await delay(100);
+    }
+    throw new Error('timeout');
+}
+
+test('endpoints integration', async () => {
+    await ensureMeili();
+    const meili = spawn('./meilisearch', ['--no-analytics', '--master-key', 'masterKey', '--http-addr', '127.0.0.1:7702'], { stdio: 'inherit' });
+    await waitForMeili();
+
+    const vault = await fs.mkdtemp(path.join(process.cwd(), 'vault-'));
+    process.env.VAULT_ROOT = vault;
+    process.env.NOTEAPI_KEY = 'testkey';
+    process.env.MEILI_MASTER_KEY = 'masterKey';
+    process.env.MEILI_HOST = MEILI_URL;
+    process.env.MEILI_INDEX = 'notes';
+
+    const notesRoute = (await import('../dist/routes/notes.js')).default;
+    const foldersRoute = (await import('../dist/routes/folders.js')).default;
+    const searchRoute = (await import('../dist/routes/search.js')).default;
+    const adminRoute = (await import('../dist/routes/admin.js')).default;
+    const app = Fastify();
+    await notesRoute(app);
+    await foldersRoute(app);
+    await searchRoute(app);
+    await adminRoute(app);
+
+    const auth = { authorization: 'Bearer testkey' };
+
+    try {
+        // Create
+        const create = await app.inject({
+            method: 'POST',
+            url: '/notes',
+            headers: auth,
+            payload: { path: 'test.md', frontmatter: { tag: 'x' }, content: 'hello' }
+        });
+        assert.equal(create.statusCode, 201);
+        const etag1 = create.headers.etag;
+        assert.ok(etag1);
+
+        // Read
+        const read = await app.inject({ method: 'GET', url: '/notes/test.md', headers: auth });
+        assert.equal(read.statusCode, 200);
+        assert.equal(read.headers.etag, etag1);
+        assert.equal(read.json().content.trim(), 'hello');
+
+        // Update
+        const upd = await app.inject({
+            method: 'PATCH',
+            url: '/notes/test.md',
+            headers: { ...auth, 'if-match': etag1 },
+            payload: { content: 'updated' }
+        });
+        assert.equal(upd.statusCode, 200);
+        const etag2 = upd.headers.etag;
+        assert.notEqual(etag2, etag1);
+
+        // Update with stale ETag
+        const stale = await app.inject({
+            method: 'PATCH',
+            url: '/notes/test.md',
+            headers: { ...auth, 'if-match': etag1 },
+            payload: { content: 'again' }
+        });
+        assert.equal(stale.statusCode, 412);
+
+        // Delete with wrong ETag
+        const delWrong = await app.inject({
+            method: 'DELETE',
+            url: '/notes/test.md',
+            headers: { ...auth, 'if-match': 'bogus' }
+        });
+        assert.equal(delWrong.statusCode, 412);
+
+        // Delete
+        const del = await app.inject({
+            method: 'DELETE',
+            url: '/notes/test.md',
+            headers: { ...auth, 'if-match': etag2 }
+        });
+        assert.equal(del.statusCode, 204);
+
+        // Path traversal
+        const trav = await app.inject({
+            method: 'POST',
+            url: '/notes',
+            headers: auth,
+            payload: { path: '../escape.md', content: 'x' }
+        });
+        assert.ok(trav.statusCode === 400 || trav.statusCode === 403);
+
+        // Nested note creation (also for search)
+        const nested = await app.inject({
+            method: 'POST',
+            url: '/notes',
+            headers: auth,
+            payload: { path: 'a/b/c/note.md', content: 'banana in folder' }
+        });
+        assert.equal(nested.statusCode, 201);
+        const nestedEtag = nested.headers.etag;
+
+        // Folders
+        const mkFolder = await app.inject({
+            method: 'POST',
+            url: '/folders',
+            headers: auth,
+            payload: { path: 'newdir' }
+        });
+        assert.equal(mkFolder.statusCode, 201);
+
+        const listFolders = await app.inject({ method: 'GET', url: '/folders', headers: auth });
+        assert.equal(listFolders.statusCode, 200);
+        assert(listFolders.json().some((f) => f.type === 'dir' && f.path === 'newdir'));
+
+        // Search
+        let searchRes;
+        await waitFor(async () => {
+            searchRes = await app.inject({ method: 'GET', url: '/search?q=banana', headers: auth });
+            return searchRes.statusCode === 200 && searchRes.json().hits.length > 0;
+        });
+        assert(searchRes.json().hits[0].snippet.includes('banana'));
+
+        const empty = await app.inject({ method: 'GET', url: '/search?q=doesnotexist', headers: auth });
+        assert.equal(empty.statusCode, 200);
+        assert.equal(empty.json().hits.length, 0);
+
+        // Admin reindex unauthorized
+        const adminNoAuth = await app.inject({ method: 'POST', url: '/admin/reindex' });
+        assert.equal(adminNoAuth.statusCode, 401);
+
+        // Admin reindex
+        const admin = await app.inject({ method: 'POST', url: '/admin/reindex', headers: auth });
+        assert.equal(admin.statusCode, 200);
+        assert(admin.json().indexed > 0);
+
+        // Search after reindex
+        let postReindex;
+        await waitFor(async () => {
+            postReindex = await app.inject({ method: 'GET', url: '/search?q=banana', headers: auth });
+            return postReindex.statusCode === 200 && postReindex.json().hits.length > 0;
+        });
+        assert(postReindex.json().hits.length > 0);
+
+        // Ensure nested note still deletable with ETag
+        const delBad = await app.inject({
+            method: 'DELETE',
+            url: '/notes/a/b/c/note.md',
+            headers: { ...auth, 'if-match': 'wrong' }
+        });
+        assert.equal(delBad.statusCode, 412);
+
+        const delNested = await app.inject({
+            method: 'DELETE',
+            url: '/notes/a/b/c/note.md',
+            headers: { ...auth, 'if-match': nestedEtag }
+        });
+        assert.equal(delNested.statusCode, 204);
+    } finally {
+        await app.close();
+        meili.kill();
+        await fs.rm(vault, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Summary
- Add integration test covering notes CRUD, folder listing/creation, search, admin reindex, ETag/If-Match handling, and path traversal protection
- Run tests sequentially by default to avoid Meilisearch contention

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a61fce2c148332ab4b06513b1b0ba3