### PR TITLE
Add graph helper endpoints and templating utilities

### DIFF
--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -285,3 +285,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchResponse'
 
+  /graph/backlinks/{path}:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getBacklinks
+      summary: List backlinks to a note
+      responses:
+        '200':
+          description: Backlinks
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  backlinks:
+                    type: array
+                    items:
+                      type: string
+                required: [backlinks]
+
+  /graph/neighbors/{path}:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getNeighbors
+      summary: List neighbors of a note
+      responses:
+        '200':
+          description: Neighbors
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  neighbors:
+                    type: array
+                    items:
+                      type: string
+                required: [neighbors]
+
+  /graph/aliases/{path}:
+    parameters:
+      - name: path
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getAliases
+      summary: List aliases for a note
+      responses:
+        '200':
+          description: Aliases
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  aliases:
+                    type: array
+                    items:
+                      type: string
+                required: [aliases]
+

--- a/src/routes/graph.ts
+++ b/src/routes/graph.ts
@@ -1,0 +1,152 @@
+import { FastifyInstance } from 'fastify';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { CONFIG } from '../config.js';
+import { vaultResolve, isMarkdown } from '../utils/paths.js';
+
+interface NoteInfo {
+    path: string;
+    links: string[];
+    aliases: string[];
+}
+
+function extractLinks(content: string): string[] {
+    const links: string[] = [];
+    const re = /\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content))) {
+        const t = m[1].trim();
+        links.push(t);
+    }
+    return links;
+}
+
+function normalizeLink(link: string): string {
+    let p = link.trim();
+    if (!p.toLowerCase().endsWith('.md')) p += '.md';
+    return p;
+}
+
+async function walk(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const e of entries) {
+        if (e.name === '.stfolder') continue;
+        if (e.name.startsWith('.')) continue;
+        const abs = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            files.push(...await walk(abs));
+        } else if (e.isFile()) {
+            if (!isMarkdown(abs)) continue;
+            if (e.name.includes('sync-conflict')) continue;
+            files.push(abs);
+        }
+    }
+    return files;
+}
+
+async function loadNotes(): Promise<NoteInfo[]> {
+    const absPaths = await walk(CONFIG.vaultRoot);
+    const notes: NoteInfo[] = [];
+    for (const abs of absPaths) {
+        const rel = path.relative(CONFIG.vaultRoot, abs).split(path.sep).join('/');
+        const buf = await fs.readFile(abs, 'utf8');
+        const parsed = matter(buf);
+        const aliasesVal = (parsed.data as any)?.aliases ?? (parsed.data as any)?.alias;
+        const aliases = Array.isArray(aliasesVal)
+            ? aliasesVal.map((a: any) => String(a))
+            : aliasesVal ? [String(aliasesVal)] : [];
+        const links = extractLinks(parsed.content).map(normalizeLink);
+        notes.push({ path: rel, links, aliases });
+    }
+    return notes;
+}
+
+export default async function route(app: FastifyInstance) {
+    app.addHook('onRequest', async (req, reply) => {
+        const auth = req.headers['authorization'];
+        const key = (auth ?? '').toString().replace(/^Bearer\s+/i, '');
+        if (!key || key !== CONFIG.apiKey) {
+            reply.code(401).send({ error: 'Unauthorized' });
+        }
+    });
+
+    app.get('/graph/aliases/*', async (req, reply) => {
+        const p = (req.params as any)['*'];
+        let abs: string;
+        try {
+            abs = vaultResolve(p);
+        } catch {
+            return reply.code(400).send({ error: 'Invalid path' });
+        }
+        if (!isMarkdown(abs)) return reply.code(400).send({ error: 'Not a Markdown path' });
+        try {
+            await fs.access(abs);
+        } catch {
+            return reply.code(404).send({ error: 'Not found' });
+        }
+        const notes = await loadNotes();
+        const note = notes.find(n => n.path === p);
+        if (!note) return reply.code(404).send({ error: 'Not found' });
+        return { aliases: note.aliases };
+    });
+
+    app.get('/graph/backlinks/*', async (req, reply) => {
+        const p = (req.params as any)['*'];
+        let abs: string;
+        try {
+            abs = vaultResolve(p);
+        } catch {
+            return reply.code(400).send({ error: 'Invalid path' });
+        }
+        if (!isMarkdown(abs)) return reply.code(400).send({ error: 'Not a Markdown path' });
+        try {
+            await fs.access(abs);
+        } catch {
+            return reply.code(404).send({ error: 'Not found' });
+        }
+        const notes = await loadNotes();
+        const note = notes.find(n => n.path === p);
+        if (!note) return reply.code(404).send({ error: 'Not found' });
+        const targetBase = p.replace(/\.md$/i, '').toLowerCase();
+        const aliasSet = new Set(note.aliases.map(a => a.toLowerCase()));
+        const backlinks = notes
+            .filter(n => n.path !== p && n.links.some(l => {
+                const base = l.replace(/\.md$/i, '').toLowerCase();
+                return base === targetBase || aliasSet.has(base);
+            }))
+            .map(n => n.path);
+        return { backlinks };
+    });
+
+    app.get('/graph/neighbors/*', async (req, reply) => {
+        const p = (req.params as any)['*'];
+        let abs: string;
+        try {
+            abs = vaultResolve(p);
+        } catch {
+            return reply.code(400).send({ error: 'Invalid path' });
+        }
+        if (!isMarkdown(abs)) return reply.code(400).send({ error: 'Not a Markdown path' });
+        try {
+            await fs.access(abs);
+        } catch {
+            return reply.code(404).send({ error: 'Not found' });
+        }
+        const notes = await loadNotes();
+        const note = notes.find(n => n.path === p);
+        if (!note) return reply.code(404).send({ error: 'Not found' });
+        const targetBase = p.replace(/\.md$/i, '').toLowerCase();
+        const aliasSet = new Set(note.aliases.map(a => a.toLowerCase()));
+        const backlinks = notes
+            .filter(n => n.path !== p && n.links.some(l => {
+                const base = l.replace(/\.md$/i, '').toLowerCase();
+                return base === targetBase || aliasSet.has(base);
+            }))
+            .map(n => n.path);
+        const neighbors = Array.from(new Set([...note.links, ...backlinks]));
+        return { neighbors };
+    });
+}
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import notes from './routes/notes.js';
 import folders from './routes/folders.js';
 import search from './routes/search.js';
 import admin from './routes/admin.js';
+import graph from './routes/graph.js';
 import { reindexAll } from './search/indexer.js';
 import { startWatcher } from './routes/watcher.js';
 
@@ -32,6 +33,7 @@ await app.register(notes);
 await app.register(folders);
 await app.register(search);
 await app.register(admin);
+await app.register(graph);
 
 try {
     const count = await reindexAll();

--- a/src/utils/templates.ts
+++ b/src/utils/templates.ts
@@ -1,0 +1,70 @@
+export type TemplateVars = Record<string, string | number>;
+
+/**
+ * Substitute {{var}} placeholders in a template string with values from vars.
+ */
+export function applyTemplate(template: string, vars: TemplateVars): string {
+    return template.replace(/\{\{\s*([\w.-]+)\s*\}\}/g, (_, key) => {
+        const val = vars[key];
+        return val === undefined ? '' : String(val);
+    });
+}
+
+interface RollItem { weight: number; value: string; }
+
+function choose(items: RollItem[], rand: () => number): string {
+    const total = items.reduce((sum, i) => sum + i.weight, 0);
+    const r = rand() * total;
+    let acc = 0;
+    for (const item of items) {
+        acc += item.weight;
+        if (r < acc) return item.value;
+    }
+    return items[items.length - 1].value;
+}
+
+/**
+ * Evaluate a roll table represented as a Markdown table or fenced block.
+ *
+ * Markdown table format:
+ * | roll | result |
+ * | ---  | ------ |
+ * | 1-2 | A |
+ * | 3 | B |
+ *
+ * Fenced block format:
+ * ```
+ * A
+ * B
+ * ```
+ */
+export function evaluateRollTable(block: string, rand: () => number = Math.random): string {
+    const trimmed = block.trim();
+    let items: RollItem[] = [];
+    if (trimmed.startsWith('```')) {
+        const lines = trimmed.split(/\r?\n/).slice(1, -1);
+        items = lines.filter(l => l.trim()).map(l => ({ weight: 1, value: l.trim() }));
+    } else {
+        const lines = trimmed.split(/\r?\n/).filter(l => l.trim().startsWith('|'));
+        if (lines.length >= 2) {
+            const dataLines = lines.slice(2); // skip header & separator
+            for (const line of dataLines) {
+                const cells = line.split('|').slice(1, -1).map(c => c.trim());
+                if (cells.length < 2) continue;
+                const weightCell = cells[0];
+                const valueCell = cells[1];
+                let weight = 1;
+                if (/^\d+$/.test(weightCell)) {
+                    weight = parseInt(weightCell, 10);
+                } else if (/^(\d+)-(\d+)$/.test(weightCell)) {
+                    const [a, b] = weightCell.split('-').map(n => parseInt(n, 10));
+                    if (!Number.isNaN(a) && !Number.isNaN(b) && b >= a) weight = b - a + 1;
+                }
+                items.push({ weight, value: valueCell });
+            }
+        }
+    }
+    if (!items.length) return '';
+    return choose(items, rand);
+}
+

--- a/test/graph.test.js
+++ b/test/graph.test.js
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import Fastify from 'fastify';
+
+function fm(content, frontmatter) {
+  const fmLines = ['---'];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    if (Array.isArray(v)) {
+      fmLines.push(`${k}:`);
+      for (const item of v) fmLines.push(`  - ${item}`);
+    } else {
+      fmLines.push(`${k}: ${v}`);
+    }
+  }
+  fmLines.push('---');
+  fmLines.push(content);
+  return fmLines.join('\n');
+}
+
+test('graph endpoints provide backlinks, neighbors, aliases', async () => {
+  const vault = await fs.mkdtemp(path.join(process.cwd(), 'vault-'));
+  process.env.VAULT_ROOT = vault;
+  process.env.NOTEAPI_KEY = 'testkey';
+
+  const graphRoute = (await import('../dist/routes/graph.js')).default;
+
+  await fs.writeFile(path.join(vault, 'a.md'), 'Link to [[b]]');
+  await fs.writeFile(path.join(vault, 'b.md'), fm('content', { aliases: ['Beta'] }));
+
+  const app = Fastify();
+  await graphRoute(app);
+
+  try {
+    const bl = await app.inject({
+      method: 'GET',
+      url: '/graph/backlinks/b.md',
+      headers: { authorization: 'Bearer testkey' }
+    });
+    assert.equal(bl.statusCode, 200);
+    assert.deepEqual(bl.json().backlinks, ['a.md']);
+
+    const al = await app.inject({
+      method: 'GET',
+      url: '/graph/aliases/b.md',
+      headers: { authorization: 'Bearer testkey' }
+    });
+    assert.deepEqual(al.json().aliases, ['Beta']);
+
+    const ne = await app.inject({
+      method: 'GET',
+      url: '/graph/neighbors/a.md',
+      headers: { authorization: 'Bearer testkey' }
+    });
+    assert.deepEqual(ne.json().neighbors, ['b.md']);
+  } finally {
+    await app.close();
+    await fs.rm(vault, { recursive: true, force: true });
+  }
+});

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { applyTemplate, evaluateRollTable } = await import('../dist/utils/templates.js');
+
+test('applyTemplate substitutes variables', () => {
+    const tpl = 'Hello {{ name }}!';
+    const res = applyTemplate(tpl, { name: 'World' });
+    assert.equal(res, 'Hello World!');
+});
+
+test('evaluateRollTable chooses based on weights', () => {
+    const table = `| roll | result |\n| --- | --- |\n| 1 | A |\n| 2 | B |`;
+    const first = evaluateRollTable(table, () => 0);
+    const second = evaluateRollTable(table, () => 0.9);
+    assert.equal(first, 'A');
+    assert.equal(second, 'B');
+    const block = "```\nX\nY\n```";
+    const blockRes = evaluateRollTable(block, () => 0.5);
+    assert.ok(['X', 'Y'].includes(blockRes));
+});


### PR DESCRIPTION
## Summary
- add `/graph` endpoints for backlinks, neighbors and aliases
- add template utilities with variable substitution and roll-table evaluation
- register indexing watcher and graph routes in server

## Testing
- `NODE_TEST_WORKERS=1 node --test test/templates.test.js test/graph.test.js test/notes.test.js test/watcher.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a62693b1a88332a9d7cab5d78b6c5b