### PR TITLE
Accept ETags via query parameter for note updates

### DIFF
--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -145,8 +145,8 @@ paths:
           required: true
           schema:
             type: string
-        - name: If-Match
-          in: header
+        - name: ifMatch
+          in: query
           required: true
           schema:
             type: string
@@ -185,8 +185,8 @@ paths:
           required: true
           schema:
             type: string
-        - name: If-Match
-          in: header
+        - name: ifMatch
+          in: query
           required: true
           schema:
             type: string

--- a/src/routes/notes.ts
+++ b/src/routes/notes.ts
@@ -107,10 +107,17 @@ export default async function route(app: FastifyInstance) {
     });
 
 
-    app.patch('/notes/*', async (req, reply) => {
+    app.patch('/notes/*', {
+        schema: {
+            querystring: {
+                type: 'object',
+                properties: { ifMatch: { type: 'string' } }
+            }
+        }
+    }, async (req, reply) => {
         const p = (req.params as any)['*'];
         const abs = vaultResolve(p);
-        const ifMatch = req.headers['if-match'];
+        const ifMatch = (req.headers['if-match'] ?? (req.query as any).ifMatch) as string | undefined;
         if (!ifMatch) return reply.code(412).send({ error: 'Missing If-Match' });
         const cur = await fs.readFile(abs);
         const curTag = strongEtagFromBuffer(cur);
@@ -160,10 +167,17 @@ export default async function route(app: FastifyInstance) {
     });
 
 
-    app.delete('/notes/*', async (req, reply) => {
+    app.delete('/notes/*', {
+        schema: {
+            querystring: {
+                type: 'object',
+                properties: { ifMatch: { type: 'string' } }
+            }
+        }
+    }, async (req, reply) => {
         const p = (req.params as any)['*'];
         const abs = vaultResolve(p);
-        const ifMatch = req.headers['if-match'];
+        const ifMatch = (req.headers['if-match'] ?? (req.query as any).ifMatch) as string | undefined;
         if (!ifMatch) return reply.code(412).send({ error: 'Missing If-Match' });
         const cur = await fs.readFile(abs);
         const curTag = strongEtagFromBuffer(cur);


### PR DESCRIPTION
## Summary
- allow `ifMatch` to be provided via query string for PATCH and DELETE `/notes`
- document `ifMatch` as query parameter in OpenAPI spec

## Testing
- `npm test` *(fails: Cannot find module '/workspace/obsidian-noteapi-nodejs/dist/routes/search.js'...)*
- `npx --yes swagger-cli validate openapi/noteapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a6c391d0c48332990cddcc082e0088