### PR TITLE
build before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx src/server.ts",
     "build": "tsc -p .",
+    "pretest": "npm run build",
     "start": "node dist/server.js",
     "test": "node --test --test-concurrency=1"
   },


### PR DESCRIPTION
## Summary
- build TypeScript sources automatically before tests

## Testing
- `npm test`
- `curl -s http://localhost:3000/health`
- `curl -s http://localhost:3000/openapi.json | jq '.paths | keys' | grep -E '/search|/notes' -n`
- `curl -i http://localhost:3000/notes/hello.md | head -n 5`
- `curl -i -H 'Authorization: Bearer testkey' -H 'Content-Type: application/json' -d '{"path":"temp.md","content":"Hello"}' http://localhost:3000/notes | head -n 10` *(fails: Internal Server Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d3979eac83328110278b9cca2bf1