### PR TITLE
Add export endpoint and recursive folder listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A small, typed HTTP service that gives a Custom GPT safe, full access to an Obsi
 ## Features (MVP)
 - CRUD on Markdown notes with YAML frontmatter
 - Move/rename and folder ops
+- List folders recursively
+- Export notes recursively
 - Full‑text search with highlighted snippets (Meilisearch)
 - Section/outline reads to keep LLM context small
 - Line range reads via `?range=start-end`

--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -235,16 +235,16 @@ paths:
   /folders:
     get:
       operationId: listFolders
-      summary: List folder tree
+      summary: List folders recursively
       responses:
         '200':
-          description: Tree
+          description: Folder paths
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  type: object
+                  type: string
     post:
       operationId: createFolder
       summary: Create folder
@@ -269,6 +269,32 @@ paths:
                   ok:
                     type: boolean
                 required: [ok]
+  /export:
+    get:
+      operationId: exportNotes
+      summary: Export notes recursively
+      parameters:
+        - in: query
+          name: path
+          schema:
+            type: string
+          description: Optional folder to export from
+      responses:
+        '200':
+          description: Notes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    path:
+                      type: string
+                    frontmatter:
+                      type: object
+                    content:
+                      type: string
   /search:
     get:
       operationId: searchNotes

--- a/src/routes/export.ts
+++ b/src/routes/export.ts
@@ -1,0 +1,54 @@
+import { FastifyInstance } from 'fastify';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { CONFIG } from '../config.js';
+import { vaultResolve, isMarkdown } from '../utils/paths.js';
+
+async function walk(rel: string): Promise<any[]> {
+    const abs = vaultResolve(rel);
+    const out: any[] = [];
+    const entries = await fs.readdir(abs, { withFileTypes: true });
+    for (const e of entries) {
+        if (e.name.startsWith('.')) continue;
+        const relPath = path.posix.join(rel, e.name);
+        const absPath = path.join(abs, e.name);
+        if (e.isDirectory()) {
+            out.push(...await walk(relPath));
+        } else if (isMarkdown(absPath)) {
+            const raw = await fs.readFile(absPath, 'utf8');
+            const parsed = matter(raw);
+            out.push({ path: relPath, frontmatter: parsed.data ?? {}, content: parsed.content });
+        }
+    }
+    return out;
+}
+
+export default async function route(app: FastifyInstance) {
+    app.addHook('onRequest', async (req, reply) => {
+        const auth = req.headers['authorization'];
+        const key = (auth ?? '').toString().replace(/^Bearer\s+/i, '');
+        if (!key || key !== CONFIG.apiKey) {
+            reply.code(401).send({ error: 'Unauthorized' });
+        }
+    });
+
+    app.get('/export', {
+        schema: {
+            querystring: {
+                type: 'object',
+                properties: {
+                    path: { type: 'string' }
+                }
+            }
+        }
+    }, async (req, reply) => {
+        const { path: rel = '' } = req.query as any;
+        try {
+            vaultResolve(rel);
+        } catch {
+            return reply.code(400).send({ error: 'Invalid path' });
+        }
+        return await walk(rel);
+    });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import folders from './routes/folders.js';
 import search from './routes/search.js';
 import admin from './routes/admin.js';
 import graph from './routes/graph.js';
+import exporter from './routes/export.js';
 import { reindexAll } from './search/indexer.js';
 import { startWatcher } from './routes/watcher.js';
 
@@ -34,6 +35,7 @@ await app.register(folders);
 await app.register(search);
 await app.register(admin);
 await app.register(graph);
+await app.register(exporter);
 
 try {
     const count = await reindexAll();

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -21,3 +21,12 @@ test('GET /folders without auth should be unauthorized', async () => {
     assert.strictEqual(res.statusCode, 401);
     await app.close();
 });
+
+test('GET /export without auth should be unauthorized', async () => {
+    const exportRoute = (await import('../dist/routes/export.js')).default;
+    const app = Fastify();
+    await exportRoute(app);
+    const res = await app.inject({ method: 'GET', url: '/export' });
+    assert.strictEqual(res.statusCode, 401);
+    await app.close();
+});


### PR DESCRIPTION
## Summary
- List folders recursively and return flat paths
- Provide new `/export` endpoint to dump notes recursively
- Update OpenAPI spec, docs, and tests

## Testing
- `npm test`
- `curl -s http://127.0.0.1:3000/health`
- `curl -s http://127.0.0.1:3000/openapi.json | jq '.paths | keys'`
- `curl -s -H "Authorization: Bearer testkey" http://127.0.0.1:3000/folders`
- `curl -s -H "Authorization: Bearer testkey" http://127.0.0.1:3000/export`
- `curl -s -H "Authorization: Bearer testkey" 'http://127.0.0.1:3000/search?q=banana'`
- `curl -s -o /tmp/admin_noauth.log -w '%{http_code}' -X POST http://127.0.0.1:3000/admin/reindex`
- `curl -s -H "Authorization: Bearer testkey" -X POST http://127.0.0.1:3000/admin/reindex`


------
https://chatgpt.com/codex/tasks/task_e_68a6f7b76f0c8332a5ad03440ed6915b