### PR TITLE
Handle missing Meilisearch gracefully

### DIFF
--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import { index, decodePath } from '../search/meili.js';
+import { index, decodePath, searchEnabled } from '../search/meili.js';
 import { CONFIG } from '../config.js';
 
 
@@ -24,7 +24,11 @@ export default async function route(app: FastifyInstance) {
                 }
             }
         }
-    }, async (req) => {
+    }, async (req, reply) => {
+        if (!searchEnabled || !index) {
+            reply.code(503).send({ error: 'Search index unavailable' });
+            return;
+        }
         const { q, limit } = req.query as { q: string; limit?: number };
         const res = await index.search(q, {
             limit,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,6 +15,7 @@ import graph from './routes/graph.js';
 import exporter from './routes/export.js';
 import { reindexAll } from './search/indexer.js';
 import { startWatcher } from './routes/watcher.js';
+import { searchEnabled } from './search/meili.js';
 
 const openapi = parse(
     fs.readFileSync(new URL('../openapi/noteapi.yaml', import.meta.url), 'utf8')
@@ -39,7 +40,11 @@ await app.register(exporter);
 
 try {
     const count = await reindexAll();
-    app.log.info(`Indexed ${count} notes`);
+    if (searchEnabled) {
+        app.log.info(`Indexed ${count} notes`);
+    } else {
+        app.log.warn('Search index unavailable; skipping indexing');
+    }
 } catch (err) {
     app.log.error({ err }, 'Failed to build search index');
 }


### PR DESCRIPTION
## Summary
- tolerate unavailable Meilisearch by gating index creation
- guard routes and watcher when search is disabled
- log warning during startup if Meilisearch can't be reached

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6fdaf8a5c833288b1d36682ffdf08