### PR TITLE
feat: add notes listing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A small, typed HTTP service that gives a Custom GPT safe, full access to an Obsi
 - CRUD on Markdown notes with YAML frontmatter
 - Move/rename and folder ops
 - List folders recursively
+- List notes recursively
 - Export notes recursively
 - Full‑text search with highlighted snippets (Meilisearch)
 - Section/outline reads to keep LLM context small

--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -76,6 +76,24 @@ paths:
                     type: boolean
                 required: [ok]
   /notes:
+    get:
+      operationId: listNotes
+      summary: List notes recursively
+      parameters:
+        - in: query
+          name: path
+          schema:
+            type: string
+          description: Optional folder to list from
+      responses:
+        '200':
+          description: Note paths
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
     post:
       operationId: createNote
       summary: Create note

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -13,6 +13,15 @@ test('GET /search without auth should be unauthorized', async () => {
     await app.close();
 });
 
+test('GET /notes without auth should be unauthorized', async () => {
+    const notesRoute = (await import('../dist/routes/notes.js')).default;
+    const app = Fastify();
+    await notesRoute(app);
+    const res = await app.inject({ method: 'GET', url: '/notes' });
+    assert.strictEqual(res.statusCode, 401);
+    await app.close();
+});
+
 test('GET /folders without auth should be unauthorized', async () => {
     const foldersRoute = (await import('../dist/routes/folders.js')).default;
     const app = Fastify();

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -148,12 +148,19 @@ test('endpoints integration', async () => {
          const folders = listFolders.json();
          assert(folders.includes('newdir'));
          assert(folders.includes('a'));
-         assert(folders.includes('a/b'));
-         assert(folders.includes('a/b/c'));
+        assert(folders.includes('a/b'));
+        assert(folders.includes('a/b/c'));
 
-         const expAll = await app.inject({ method: 'GET', url: '/export', headers: auth });
-         assert.equal(expAll.statusCode, 200);
-         assert(expAll.json().some((n) => n.path === 'a/b/c/note.md'));
+        const listNotes = await app.inject({ method: 'GET', url: '/notes', headers: auth });
+        assert.equal(listNotes.statusCode, 200);
+        assert(listNotes.json().includes('a/b/c/note.md'));
+
+        const listSub = await app.inject({ method: 'GET', url: '/notes?path=a', headers: auth });
+        assert(listSub.json().every((n) => n.startsWith('a/')));
+
+        const expAll = await app.inject({ method: 'GET', url: '/export', headers: auth });
+        assert.equal(expAll.statusCode, 200);
+        assert(expAll.json().some((n) => n.path === 'a/b/c/note.md'));
 
          const expSub = await app.inject({ method: 'GET', url: '/export?path=a', headers: auth });
          assert(expSub.json().every((n) => n.path.startsWith('a/')));


### PR DESCRIPTION
## Summary
- add GET /notes to list all note paths recursively
- document new endpoint and list-notes feature
- test notes listing and auth guard

## Testing
- `npm test`
- `curl -s http://127.0.0.1:3000/health`
- `curl -s http://127.0.0.1:3000/openapi.json | jq '.paths | keys'`
- `curl -s -i http://127.0.0.1:3000/notes`
- `curl -s -H 'Authorization: Bearer testkey' 'http://127.0.0.1:3000/notes?path=projects' | jq '.'`


------
https://chatgpt.com/codex/tasks/task_e_68a734991eec8332b73db393be06358f