### PR TITLE
fix: return etag in note response

### DIFF
--- a/src/routes/notes.ts
+++ b/src/routes/notes.ts
@@ -121,7 +121,7 @@ export default async function route(app: FastifyInstance) {
         let content = contentLines.join('\n');
         if (section && !range) content = content.trim();
 
-        return { frontmatter: parsed.data ?? {}, content, toc };
+        return { path: p, frontmatter: parsed.data ?? {}, content, toc, etag };
     });
 
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import helmet from '@fastify/helmet';
 import rateLimit from '@fastify/rate-limit';
 import fs from 'node:fs';
 import { parse } from 'yaml';
+import pino from 'pino';
 import { CONFIG } from './config.js';
 
 // Routes
@@ -21,7 +22,10 @@ const openapi = parse(
     fs.readFileSync(new URL('../openapi/noteapi.yaml', import.meta.url), 'utf8')
 );
 
-const app = Fastify({ logger: true, bodyLimit: 2 * 1024 * 1024 });
+const app = Fastify({
+    logger: { timestamp: pino.stdTimeFunctions.isoTime },
+    bodyLimit: 2 * 1024 * 1024
+});
 await app.register(helmet);
 await app.register(rateLimit, { max: 300, timeWindow: '1 minute' });
 


### PR DESCRIPTION
## Summary
- output ISO-formatted timestamps in Fastify logger
- return ETag value in GET note responses for safe updates

## Testing
- `npm test`
- `curl -s localhost:3000/health`
- `curl -s $API/openapi.json | grep -o '"/search"'`
- `curl -s $API/openapi.json | grep -o '"/notes"'`
- `curl -s -o /dev/null -w "%{http_code}" $API/notes/hello.md`
- `curl -s -D - -H "$AUTH" -H 'Content-Type: application/json' -d '{"path":"testnote.md","frontmatter":{"tag":"a"},"content":"hello world\n\n## Section\nMore"}' $API/notes`
- `curl -s -D - -H "$AUTH" $API/notes/testnote.md`
- `curl -s -H "$AUTH" "$API/notes/testnote.md?section=Section"`
- `curl -s -H "$AUTH" $API/notes/testnote.md | jq '.etag'`
- `curl -s -D - -H "$AUTH" -H "If-Match: $ETAG" -H 'Content-Type: application/json' -d '{"content":"updated content"}' -X PATCH $API/notes/testnote.md`
- `curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" -H "If-Match: $ETAG" -H 'Content-Type: application/json' -d '{"content":"again"}' -X PATCH $API/notes/testnote.md`
- `curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" -H "If-Match: $ETAG2" -X DELETE $API/notes/testnote.md`
- `curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" -H 'Content-Type: application/json' -d '{"path":"newdir"}' -X POST $API/folders`
- `curl -s -H "$AUTH" $API/folders`
- `curl -s -H "$AUTH" "$API/search?q=banana"`
- `curl -s -H "$AUTH" "$API/search?q=doesnotexist"`
- `curl -s -o /dev/null -w "%{http_code}" -X POST $API/admin/reindex`
- `curl -s -H "$AUTH" -X POST $API/admin/reindex`
- `curl -s -H "$AUTH" "$API/search?q=banana"`
- `curl -s -o /dev/null -w "%{http_code}" -H "$AUTH" -H 'Content-Type: application/json' -d '{"path":"../escape.md","content":"x"}' -X POST $API/notes`
- `curl -s -D - -H "$AUTH" -H 'Content-Type: application/json' -d '{"path":"a/b/c/note.md","content":"banana in folder"}' $API/notes`
- `curl -s -D - -H "$AUTH" -H 'Content-Type: application/json' --data-binary @big.json $API/notes`
- `curl -s -H "$AUTH" $API/notes/big.md -o /tmp/big_get.log`
- `wc -c /tmp/big_get.log`
- `curl -s -D - -H "$AUTH" -H 'Content-Type: application/json' -d '{"path":"frontonly.md","frontmatter":{"title":"Only"}}' $API/notes`
- `curl -s -H "$AUTH" $API/notes/frontonly.md`

------
https://chatgpt.com/codex/tasks/task_e_68a7645692d883329f9f88d324d5fefb