### PR TITLE
feat: retry meilisearch index

### DIFF
--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from 'fastify';
-import { index, decodePath, searchEnabled } from '../search/meili.js';
+import { index, decodePath, searchEnabled, ensureIndex } from '../search/meili.js';
 import { CONFIG } from '../config.js';
 
 
@@ -26,8 +26,11 @@ export default async function route(app: FastifyInstance) {
         }
     }, async (req, reply) => {
         if (!searchEnabled || !index) {
-            reply.code(503).send({ error: 'Search index unavailable' });
-            return;
+            await ensureIndex();
+            if (!searchEnabled || !index) {
+                reply.code(503).send({ error: 'Search index unavailable' });
+                return;
+            }
         }
         const { q, limit } = req.query as { q: string; limit?: number };
         const res = await index.search(q, {


### PR DESCRIPTION
## Summary
- export `ensureIndex` and allow dynamic search index recovery
- retry index creation in `/search` route and server startup

## Testing
- `npm test`
- `curl http://127.0.0.1:3000/health`
- `curl -s http://127.0.0.1:3000/openapi.json | grep -o '"/search"'`
- `curl -s http://127.0.0.1:3000/openapi.json | grep -o '"/notes"' | head -n 1`
- `curl -i http://127.0.0.1:3000/notes/hello.md`
- `curl -s -H 'Authorization: Bearer testkey' "http://127.0.0.1:3000/notes/banana_note.md?section=Banana%20information"`
- `curl -i -X POST http://127.0.0.1:3000/notes ...`
- `curl -i -X PATCH http://127.0.0.1:3000/notes/newnote.md ...`
- `curl -i -X DELETE http://127.0.0.1:3000/notes/newnote.md ...`
- `curl -i -X PATCH http://127.0.0.1:3000/notes/temp.md ...`
- `curl -i -X POST http://127.0.0.1:3000/folders ...`
- `curl -s -H 'Authorization: Bearer testkey' http://127.0.0.1:3000/folders`
- `curl -i -X POST http://127.0.0.1:3000/admin/reindex`
- `curl -i -X POST http://127.0.0.1:3000/admin/reindex -H 'Authorization: Bearer testkey'`
- `curl -s -H 'Authorization: Bearer testkey' "http://127.0.0.1:3000/search?q=banana"`
- `curl -i -X POST http://127.0.0.1:3000/notes -H 'Authorization: Bearer testkey' -H 'Content-Type: application/json' -d '{"path":"../escape.md","content":"x"}'`
- `curl -i -X POST http://127.0.0.1:3000/notes -H 'Authorization: Bearer testkey' -H 'Content-Type: application/json' -d '{"path":"a/b/c/note.md","content":"Nested"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a8134e2edc8332829e0f56a7bf2398