### PR TITLE
Wait for Meilisearch tasks in indexer

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -29,6 +29,10 @@ You are an assistant developer. Your job is to implement endpoints and utilities
 
 - Do not use docker for tests
 - Use the latest stable Meilisearch release (currently 1.18.0) if possible https://github.com/meilisearch/meilisearch/releases/tag/v1.18.0
+- Install Meilisearch before running tests:
+  - `curl -L https://github.com/meilisearch/meilisearch/releases/download/v1.18.0/meilisearch-linux-amd64 -o meilisearch`
+  - `chmod +x meilisearch`
+  - `./meilisearch --master-key masterKey --no-analytics &`
 
 ## Tests
 - Do not use Docker for tests 

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -4,6 +4,9 @@ import matter from 'gray-matter';
 import { CONFIG } from '../config.js';
 import { index, toSearchDoc, searchEnabled } from './meili.js';
 import { isMarkdown } from '../utils/paths.js';
+import pino from 'pino';
+
+const log = pino({ level: process.env.LOG_LEVEL ?? 'info', timestamp: pino.stdTimeFunctions.isoTime });
 
 async function walk(dir: string): Promise<string[]> {
     const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -25,6 +28,7 @@ async function walk(dir: string): Promise<string[]> {
 
 export async function reindexAll(): Promise<number> {
     if (!searchEnabled || !index) return 0;
+    const idx = index;
     try {
         const absPaths = await walk(CONFIG.vaultRoot);
         const docs: any[] = [];
@@ -35,9 +39,23 @@ export async function reindexAll(): Promise<number> {
             const stat = await fs.stat(abs);
             docs.push(toSearchDoc({ path: rel, frontmatter: parsed.data ?? {}, content: parsed.content, mtime: stat.mtimeMs }));
         }
-        if (docs.length) await index.addDocuments(docs);
+        if (!docs.length) return 0;
+
+        const CHUNK_SIZE = 200;
+        for (let i = 0; i < docs.length; i += CHUNK_SIZE) {
+            const batch = docs.slice(i, i + CHUNK_SIZE);
+            const task = await idx.addDocuments(batch);
+            if ('taskUid' in task) {
+                const res = await idx.tasks.waitForTask(task.taskUid);
+                if (res.status !== 'succeeded') {
+                    log.error({ task: res }, 'Failed to index documents');
+                    return 0;
+                }
+            }
+        }
         return docs.length;
     } catch (err: any) {
+        log.error({ err }, 'Error during reindex');
         if (err?.code === 'ENOENT') return 0;
         if (err?.type === 'MeiliSearchRequestError') return 0;
         throw err;


### PR DESCRIPTION
## Summary
- batch documents when reindexing to avoid large payloads
- wait for Meilisearch indexing tasks and report failures
- log reindex errors
- document Meilisearch installation for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a821a344a483329f0a19892c5f3d69