### PR TITLE
feat: add batch note retrieval

### DIFF
--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -40,6 +40,26 @@ components:
           items:
             $ref: '#/components/schemas/TOCItem'
       required: [path, frontmatter, content, etag]
+    BatchNotesRequest:
+      type: object
+      properties:
+        paths:
+          type: array
+          items:
+            type: string
+      required: [paths]
+    BatchNotesResponse:
+      type: object
+      properties:
+        notes:
+          type: array
+          items:
+            $ref: '#/components/schemas/NoteResponse'
+        errors:
+          type: object
+          additionalProperties:
+            type: string
+      required: [notes]
     SearchResponse:
       type: object
       properties:
@@ -122,6 +142,23 @@ paths:
                   ok:
                     type: boolean
                 required: [ok]
+  /notes/batch:
+    post:
+      operationId: getNotesBatch
+      summary: Read multiple notes
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchNotesRequest'
+      responses:
+        '200':
+          description: Notes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchNotesResponse'
   /notes/{path}:
     get:
       operationId: getNote


### PR DESCRIPTION
## Summary
- add reusable readNote utility and POST /notes/batch route
- document batch notes endpoint in OpenAPI spec
- test batch retrieval of multiple notes

## Testing
- `npm test`
- `curl -s http://127.0.0.1:3000/health`
- `curl -s http://127.0.0.1:3000/openapi.json | jq '.paths | keys'`
- `curl -s -H "Authorization: Bearer testkey" -H "Content-Type: application/json" -X POST http://127.0.0.1:3000/notes/batch -d '{"paths":["x.md","y.md","missing.md"]}'`


------
https://chatgpt.com/codex/tasks/task_e_68a858d312448332863d8516df7b09fd