### PR TITLE
Ignore assets directories in search indexer and watcher

### DIFF
--- a/src/routes/watcher.ts
+++ b/src/routes/watcher.ts
@@ -43,6 +43,7 @@ export function startWatcher(): FSWatcher {
             const base = path.basename(p);
             if (base === '.stfolder') return true;
             if (base.startsWith('.')) return true;
+            if (base === 'assets') return true; // assets contain non-indexable binaries and images
             return false;
         }
     });

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -16,6 +16,7 @@ async function walk(dir: string): Promise<string[]> {
         if (e.name.startsWith('.')) continue;
         const abs = path.join(dir, e.name);
         if (e.isDirectory()) {
+            if (e.name === 'assets') continue; // assets contain non-indexable binaries and images
             files.push(...await walk(abs));
         } else if (e.isFile()) {
             if (!isMarkdown(abs)) continue;


### PR DESCRIPTION
## Summary
- Skip `assets` directories while recursively indexing files to avoid non-searchable binaries
- Ignore `assets` folders in watcher to prevent indexing non-indexable binary/image files

## Testing
- `MEILI_HOST=http://127.0.0.1:7700 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8890c6e908332a3658a6980e93732