### PR TITLE
Add file ownership controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Where your Syncthing-shared Obsidian vault is mounted on the Unraid host
 VAULT_ROOT=./sample-vault
 
+# Numeric UID/GID to apply to new files (optional)
+FILE_UID=
+FILE_GID=
+
 # Public base URL used in OpenAPI servers[] and for absolute links
 BASE_URL=https://production-url.yourdomain.com
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ A small, typed HTTP service that gives a Custom GPT safe, full access to an Obsi
 
 ## Running
 
+Set optional `FILE_UID`/`FILE_GID` in your environment to chown new files and
+directories. When using Docker Compose, you can also run the service as that
+user via `user: "${FILE_UID}:${FILE_GID}"`.
+
 ### Method 1: Docker Compose
 1. Copy `.env.example` to `.env` and set any required values (e.g. `NOTEAPI_KEY`). The default `MEILI_HOST` is `http://meili:7700`.
 2. Copy `docker-compose.yml.example` to `docker-compose.yml`.

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -27,7 +27,10 @@ services:
       - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
       - MEILI_INDEX=notes
       - BASE_URL=${BASE_URL}
+      - FILE_UID=${FILE_UID}
+      - FILE_GID=${FILE_GID}
     depends_on:
       - meili
     ports:
       - "3000:3000"
+    user: "${FILE_UID}:${FILE_GID}"

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,8 @@ export const CONFIG = {
   vaultRoot: process.env.VAULT_ROOT ?? '/vault',
   apiKey: process.env.NOTEAPI_KEY ?? '',
   trashEnabled: process.env.TRASH_ENABLED === 'true',
+  fileUid: process.env.FILE_UID ? Number(process.env.FILE_UID) : undefined,
+  fileGid: process.env.FILE_GID ? Number(process.env.FILE_GID) : undefined,
   meili: {
     host: process.env.MEILI_HOST ?? 'http://127.0.0.1:7700',
     key: process.env.MEILI_MASTER_KEY ?? '',

--- a/src/routes/folders.ts
+++ b/src/routes/folders.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { CONFIG } from '../config.js';
+import { applyOwnership } from '../utils/ownership.js';
 
 
 async function listDirs(dir: string, base = ''): Promise<string[]> {
@@ -38,6 +39,7 @@ export default async function route(app: FastifyInstance) {
         const { path: rel } = req.body as any;
         const abs = path.join(CONFIG.vaultRoot, rel);
         await fs.mkdir(abs, { recursive: true });
+        await applyOwnership(abs);
         reply.code(201).send({ ok: true });
     });
 }

--- a/src/routes/notes.ts
+++ b/src/routes/notes.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs/promises';
 import fssync from 'node:fs';
 import path from 'node:path';
 import { vaultResolve, isMarkdown, ensureParentDir } from '../utils/paths.js';
+import { applyOwnership } from '../utils/ownership.js';
 import { CONFIG } from '../config.js';
 import matter from 'gray-matter';
 import { strongEtagFromBuffer } from '../utils/etag.js';
@@ -18,6 +19,7 @@ async function writeNoteAtomic(absPath: string, buffer: Buffer) {
         await handle.close();
     }
     await fs.rename(tmp, absPath);
+    await applyOwnership(absPath);
 }
 
 async function listNotes(rel: string): Promise<string[]> {

--- a/src/utils/ownership.ts
+++ b/src/utils/ownership.ts
@@ -1,0 +1,8 @@
+import fs from 'node:fs';
+import { CONFIG } from '../config.js';
+
+export async function applyOwnership(p: string): Promise<void> {
+  if (CONFIG.fileUid !== undefined && CONFIG.fileGid !== undefined) {
+    await fs.promises.chown(p, CONFIG.fileUid, CONFIG.fileGid);
+  }
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { CONFIG } from '../config.js';
+import { applyOwnership } from './ownership.js';
 
 const REAL_VAULT_ROOT = fs.existsSync(CONFIG.vaultRoot)
     ? fs.realpathSync(CONFIG.vaultRoot)
@@ -35,5 +36,7 @@ export function vaultResolve(rel: string): string {
 }
 
 export async function ensureParentDir(absPath: string): Promise<void> {
-  await fsp.mkdir(path.dirname(absPath), { recursive: true });
+  const dir = path.dirname(absPath);
+  await fsp.mkdir(dir, { recursive: true });
+  await applyOwnership(dir);
 }


### PR DESCRIPTION
## Summary
- support optional FILE_UID/FILE_GID config for chowning new files
- apply ownership after writing notes and creating directories
- document ownership env vars and docker-compose usage

## Testing
- `MEILI_HOST=http://127.0.0.1:7700 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af55eed29c83328c849740b9f6e1ae