### PR TITLE
Use BASE_URL for OpenAPI server URL

### DIFF
--- a/openapi/noteapi.yaml
+++ b/openapi/noteapi.yaml
@@ -3,7 +3,7 @@ info:
   title: NoteAPI
   version: 0.1.0
 servers:
-  - url: https://noteapi.gould.pro
+  - url: ${BASE_URL}
 security:
   - bearerAuth: []
 components:

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { searchEnabled, ensureIndex } from './search/meili.js';
 const openapi = parse(
     fs.readFileSync(new URL('../openapi/noteapi.yaml', import.meta.url), 'utf8')
 );
+openapi.servers = [{ url: CONFIG.baseUrl }];
 
 const app = Fastify({
     logger: { timestamp: pino.stdTimeFunctions.isoTime },


### PR DESCRIPTION
## Summary
- use ${BASE_URL} placeholder in OpenAPI spec
- set OpenAPI server URL from CONFIG.baseUrl

## Testing
- `npm test` *(fails: The provided API key is invalid)*
- `curl -s http://127.0.0.1:4000/openapi.json | jq '.servers'`


------
https://chatgpt.com/codex/tasks/task_e_68b0b8bb0b3483329554bb02466a483b